### PR TITLE
Disable spgist index checking & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ admin@mydb=# CREATE EXTENSION pgstattuple;
 pg_bloat_check.py -c dbname=mydb --create_stats_table
 
 pg_bloat_check.py -c "host=192.168.1.201 dbname=mydb user=admin" --create_stats_table --bloat_schema=monitoring
+
+pg_bloat_check.py -c "host=db.example.com dbname=prod_db user=prod_role options='-c statement_timeout=0'" --create_stats_table --bloat_schema=monitoring
 ```
 
-The first example above installs the stats tables to the default schema in your search path. You only have to run that once per database and if you run it again, it just drops the table if it exists and recreates it. If you want it in a different schema, `--bloat_schema` lets you set that, but you must then use that option every time you run the script or add that schema to your search path. The second example shows that as well as connecting to a remote system.
+The first example above installs the stats tables to the default schema in your search path. You only have to run that once per database and if you run it again, it just drops the table if it exists and recreates it. If you want it in a different schema, `--bloat_schema` lets you set that, but you must then use that option every time you run the script or add that schema to your search path. The second example shows that as well as connecting to a remote system. The third example shows how you can disable a server side statement_timeouts using the psycopg2 connection options for the session.
 
 ```
 pg_bloat_check.py -c dbname=mydb -z 10485760 -p 45 -s 5242880 

--- a/pg_bloat_check.py
+++ b/pg_bloat_check.py
@@ -182,7 +182,9 @@ def get_bloat(conn, exclude_schema_list, include_schema_list, exclude_object_lis
                     JOIN pg_catalog.pg_am a ON c.relam = a.oid
                     WHERE c.relkind = 'i' 
                     AND c.relpersistence <> 't'
-                    AND a.amname <> 'gin' AND a.amname <> 'brin' """
+                    AND a.amname <> 'gin'
+                    AND a.amname <> 'brin'
+                    AND a.amname <> 'spgist' """
 
 
     cur.execute("SELECT current_setting('server_version_num')::int >= 90300")


### PR DESCRIPTION
Disable `spgist` index checking as per BRIN & GIN indexes.
`spgist` indexes caused the tool to fail.

Add a note to the readme about how to use the options parameter to disable server side query statement_timeout using the local session setting.